### PR TITLE
Update README with Windows-Specific Installation Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,19 @@ Torch developers.)
 ## Table of Content
 - [Projects using L4CasADi](#projects-using-l4casadi)
 - [Installation](#installation)
+    - [Prerequisites](#prerequisites)
+    - [Windows Installation](#windows-installation)
+    - [Pip Install (CPU Only)](#pip-install-cpu-only)
+    - [From Source (CPU Only)](#from-source-cpu-only)
+    - [GPU (CUDA)](#gpu-cuda)
 - [Quick Start](#quick-start)
 - [Online Learning](#online-learning-and-updating)
 - [Naive L4CasADi](#naive-l4casadi) - Use this for small Multi Layer Perceptron Models.
 - [Real-time L4CasADi](#real-time-l4casadi) - Use this for fast MPC with Acados.
 - [Examples](#examples)
 
-If you use this framework please cite the following two paper
+If you use this framework please cite the following two papers:
+
 ```
 @article{salzmann2023neural,
   title={Real-time Neural-MPC: Deep Learning Model Predictive Control for Quadrotors and Agile Robotic Platforms},
@@ -93,9 +99,22 @@ If your project is using L4CasADi and you would like to be featured here, please
 ### Prerequisites
 Independently if you install from source or via pip you will need to meet the following requirements:
 
-- Working build system: CMake compatible C++ compiler (GCC version 10 or higher).
+- Working build system: CMake compatible C++ compiler.
+    - **On Linux/macOS:** GCC version 10 or higher is recommended.
+    - **On Windows:** You must install CMake and **Visual C++ Build Tools** (do not use a GCC compiler).
 - PyTorch (`>=2.0`) installation in your python environment.\
 `python -c "import torch; print(torch.__version__)"`
+
+### Windows Installation
+
+For users installing on Windows, please ensure the following steps are taken:
+
+1. **Install CMake and Visual C++ Build Tools:**
+Download and install [CMake](https://cmake.org/download/) and the [Visual C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/).
+2. **Ensure Tools Are on Your PATH:**
+Make sure both CMake and the Visual C++ Build Tools are added to your system's PATH. This can be done either via the installers (by selecting the option to update the PATH) or manually.
+3. **Mind the File Path Length:**
+When building the L4CasADi model, ensure that the directory path does not exceed Windows’ maximum character limit. Long paths might lead to build issues, so choose a directory with a short path if possible.
 
 ### Pip Install (CPU Only)
 - Ensure Torch CPU-version is installed\


### PR DESCRIPTION
This pull request updates the README to include detailed, Windows-specific installation instructions. The changes are intended to help Windows users successfully build and install L4CasADi without encountering common pitfalls such as using an unsupported compiler or running into file path length issues. Key additions include:

Windows Prerequisites:
Guidance on installing CMake and Visual C++ Build Tools instead of a GCC compiler.

PATH Configuration:
Instructions to ensure both CMake and the Visual C++ Build Tools are correctly added to the system PATH.

File Path Length Considerations:
A note to avoid overly long directory paths during the build process to prevent Windows path length limitations.

These modifications aim to streamline the setup process for Windows users, improving overall user experience and reducing installation errors on that platform. Please review and merge if acceptable.