### PR TITLE
fix: raise CMake minimum required version to 3.13

### DIFF
--- a/libl4casadi/CMakeLists.txt
+++ b/libl4casadi/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 project(L4CasADi)
 
 set(CMAKE_COMPILE_WARNING_AS_ERROR OFF)


### PR DESCRIPTION
CMake versions >=3.27 fail to configure the project due to deprecated support for older cmake_minimum_required values. This change updates the minimum required version to 3.13 to ensure compatibility with modern toolchains.