### PR TITLE
Update CMake minimum version to 3.5

### DIFF
--- a/libl4casadi/CMakeLists.txt
+++ b/libl4casadi/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 project(L4CasADi)
 
 set(CMAKE_COMPILE_WARNING_AS_ERROR OFF)


### PR DESCRIPTION
When building CasADI from source (CPU only, according to [install instructions](https://github.com/Tim-Salzmann/l4casadi?tab=readme-ov-file#from-source-cpu-only)), the build fails with the following error message:

```
Processing /home/amon/Repositories/l4casadi_fork
  Preparing metadata (pyproject.toml) ... done
Requirement already satisfied: jinja2>=3.1 in /home/amon/.pyenv/versions/3.10.6/envs/l4casadi_install_2/lib/python3.10/site-packages (from l4casadi==2.0.0) (3.1.4)
Collecting casadi>=3.6
  Using cached casadi-3.7.0-cp310-none-manylinux2014_x86_64.whl (77.3 MB)
Requirement already satisfied: torch in /home/amon/.pyenv/versions/3.10.6/envs/l4casadi_install_2/lib/python3.10/site-packages (from l4casadi==2.0.0) (2.7.1+cpu)
Collecting numpy
  Using cached numpy-2.2.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (16.8 MB)
Requirement already satisfied: MarkupSafe>=2.0 in /home/amon/.pyenv/versions/3.10.6/envs/l4casadi_install_2/lib/python3.10/site-packages (from jinja2>=3.1->l4casadi==2.0.0) (2.1.5)
Requirement already satisfied: fsspec in /home/amon/.pyenv/versions/3.10.6/envs/l4casadi_install_2/lib/python3.10/site-packages (from torch->l4casadi==2.0.0) (2024.6.1)
Requirement already satisfied: filelock in /home/amon/.pyenv/versions/3.10.6/envs/l4casadi_install_2/lib/python3.10/site-packages (from torch->l4casadi==2.0.0) (3.13.1)
Requirement already satisfied: typing-extensions>=4.10.0 in /home/amon/.pyenv/versions/3.10.6/envs/l4casadi_install_2/lib/python3.10/site-packages (from torch->l4casadi==2.0.0) (4.12.2)
Requirement already satisfied: networkx in /home/amon/.pyenv/versions/3.10.6/envs/l4casadi_install_2/lib/python3.10/site-packages (from torch->l4casadi==2.0.0) (3.3)
Requirement already satisfied: sympy>=1.13.3 in /home/amon/.pyenv/versions/3.10.6/envs/l4casadi_install_2/lib/python3.10/site-packages (from torch->l4casadi==2.0.0) (1.13.3)
Requirement already satisfied: mpmath<1.4,>=1.1.0 in /home/amon/.pyenv/versions/3.10.6/envs/l4casadi_install_2/lib/python3.10/site-packages (from sympy>=1.13.3->torch->l4casadi==2.0.0) (1.3.0)
Building wheels for collected packages: l4casadi
  Building wheel for l4casadi (pyproject.toml) ... error
  error: subprocess-exited-with-error
  
  × Building wheel for l4casadi (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [107 lines of output]
      /home/amon/.pyenv/versions/3.10.6/envs/l4casadi_install_2/lib/python3.10/site-packages/torch/_subclasses/functional_tensor.py:276: UserWarning: Failed to initialize NumPy: No module named 'numpy' (Triggered internally at /pytorch/torch/csrc/utils/tensor_numpy.cpp:81.)
        cpu = _conversion_method_template(device=torch.device("cpu"))
      /home/amon/.pyenv/versions/3.10.6/envs/l4casadi_install_2/lib/python3.10/site-packages/setuptools/config/_apply_pyprojecttoml.py:61: SetuptoolsDeprecationWarning: License classifiers are deprecated.
      !!
      
              ********************************************************************************
              Please consider removing the following classifiers in favor of a SPDX license expression:
      
              License :: OSI Approved :: MIT License
      
              See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
              ********************************************************************************
      
      !!
        dist._finalize_license_expression()
      /home/amon/.pyenv/versions/3.10.6/envs/l4casadi_install_2/lib/python3.10/site-packages/setuptools/dist.py:759: SetuptoolsDeprecationWarning: License classifiers are deprecated.
      !!
      
              ********************************************************************************
              Please consider removing the following classifiers in favor of a SPDX license expression:
      
              License :: OSI Approved :: MIT License
      
              See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
              ********************************************************************************
      
      !!
        self._finalize_license_expression()
      
      
      --------------------------------------------------------------------------------
      -- Trying 'Ninja' generator
      --------------------------------
      ---------------------------
      ----------------------
      -----------------
      ------------
      -------
      --
      CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
        Compatibility with CMake < 3.10 will be removed from a future version of
        CMake.
      
        Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
        to tell CMake that the project requires at least <min> but has been updated
        to work with policies introduced by <max> or earlier.
      
      Not searching for unused variables given on the command line.
      
      -- The C compiler identification is GNU 11.4.0
      -- Detecting C compiler ABI info
      -- Detecting C compiler ABI info - done
      -- Check for working C compiler: /usr/bin/cc - skipped
      -- Detecting C compile features
      -- Detecting C compile features - done
      -- The CXX compiler identification is GNU 11.4.0
      -- Detecting CXX compiler ABI info
      -- Detecting CXX compiler ABI info - done
      -- Check for working CXX compiler: /usr/bin/c++ - skipped
      -- Detecting CXX compile features
      -- Detecting CXX compile features - done
      -- Configuring done (0.2s)
      -- Generating done (0.0s)
      -- Build files have been written to: /home/amon/Repositories/l4casadi_fork/_cmake_test_compile/build
      --
      -------
      ------------
      -----------------
      ----------------------
      ---------------------------
      --------------------------------
      -- Trying 'Ninja' generator - success
      --------------------------------------------------------------------------------
      
      Configuring Project
        Working directory:
          /home/amon/Repositories/l4casadi_fork/_skbuild/linux-x86_64-3.10/cmake-build
        Command:
          /home/amon/.pyenv/versions/3.10.6/envs/l4casadi_install_2/lib/python3.10/site-packages/cmake/data/bin/cmake /home/amon/Repositories/l4casadi_fork/libl4casadi -G Ninja -DCMAKE_MAKE_PROGRAM:FILEPATH=/home/amon/.pyenv/versions/3.10.6/envs/l4casadi_install_2/bin/ninja --no-warn-unused-cli -DCMAKE_INSTALL_PREFIX:PATH=/home/amon/Repositories/l4casadi_fork/_skbuild/linux-x86_64-3.10/cmake-install -DPYTHON_VERSION_STRING:STRING=3.10.6 -DSKBUILD:INTERNAL=TRUE -DCMAKE_MODULE_PATH:PATH=/home/amon/.pyenv/versions/3.10.6/envs/l4casadi_install_2/lib/python3.10/site-packages/skbuild/resources/cmake -DPYTHON_EXECUTABLE:PATH=/home/amon/.pyenv/versions/3.10.6/envs/l4casadi_install_2/bin/python3.10 -DPYTHON_INCLUDE_DIR:PATH=/home/amon/.pyenv/versions/3.10.6/include/python3.10 -DPYTHON_LIBRARY:PATH=/home/amon/.pyenv/versions/3.10.6/lib/libpython3.10.a -DPython_EXECUTABLE:PATH=/home/amon/.pyenv/versions/3.10.6/envs/l4casadi_install_2/bin/python3.10 -DPython_ROOT_DIR:PATH=/home/amon/.pyenv/versions/3.10.6/envs/l4casadi_install_2 -DPython_FIND_REGISTRY:STRING=NEVER -DPython_INCLUDE_DIR:PATH=/home/amon/.pyenv/versions/3.10.6/include/python3.10 -DPython3_EXECUTABLE:PATH=/home/amon/.pyenv/versions/3.10.6/envs/l4casadi_install_2/bin/python3.10 -DPython3_ROOT_DIR:PATH=/home/amon/.pyenv/versions/3.10.6/envs/l4casadi_install_2 -DPython3_FIND_REGISTRY:STRING=NEVER -DPython3_INCLUDE_DIR:PATH=/home/amon/.pyenv/versions/3.10.6/include/python3.10 -DCMAKE_MAKE_PROGRAM:FILEPATH=/home/amon/.pyenv/versions/3.10.6/envs/l4casadi_install_2/bin/ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_TORCH_PATH=/home/amon/.pyenv/versions/3.10.6/envs/l4casadi_install_2/lib/python3.10/site-packages/torch
      
      CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
        Compatibility with CMake < 3.5 has been removed from CMake.
      
        Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
        to tell CMake that the project requires at least <min> but has been updated
        to work with policies introduced by <max> or earlier.
      
        Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
      
      Not searching for unused variables given on the command line.
      
      -- Configuring incomplete, errors occurred!
      Traceback (most recent call last):
        File "/home/amon/.pyenv/versions/3.10.6/envs/l4casadi_install_2/lib/python3.10/site-packages/skbuild/setuptools_wrap.py", line 660, in setup
          env = cmkr.configure(
        File "/home/amon/.pyenv/versions/3.10.6/envs/l4casadi_install_2/lib/python3.10/site-packages/skbuild/cmaker.py", line 354, in configure
          raise SKBuildError(msg)
      
      An error occurred while configuring with CMake.
        Command:
          /home/amon/.pyenv/versions/3.10.6/envs/l4casadi_install_2/lib/python3.10/site-packages/cmake/data/bin/cmake /home/amon/Repositories/l4casadi_fork/libl4casadi -G Ninja -DCMAKE_MAKE_PROGRAM:FILEPATH=/home/amon/.pyenv/versions/3.10.6/envs/l4casadi_install_2/bin/ninja --no-warn-unused-cli -DCMAKE_INSTALL_PREFIX:PATH=/home/amon/Repositories/l4casadi_fork/_skbuild/linux-x86_64-3.10/cmake-install -DPYTHON_VERSION_STRING:STRING=3.10.6 -DSKBUILD:INTERNAL=TRUE -DCMAKE_MODULE_PATH:PATH=/home/amon/.pyenv/versions/3.10.6/envs/l4casadi_install_2/lib/python3.10/site-packages/skbuild/resources/cmake -DPYTHON_EXECUTABLE:PATH=/home/amon/.pyenv/versions/3.10.6/envs/l4casadi_install_2/bin/python3.10 -DPYTHON_INCLUDE_DIR:PATH=/home/amon/.pyenv/versions/3.10.6/include/python3.10 -DPYTHON_LIBRARY:PATH=/home/amon/.pyenv/versions/3.10.6/lib/libpython3.10.a -DPython_EXECUTABLE:PATH=/home/amon/.pyenv/versions/3.10.6/envs/l4casadi_install_2/bin/python3.10 -DPython_ROOT_DIR:PATH=/home/amon/.pyenv/versions/3.10.6/envs/l4casadi_install_2 -DPython_FIND_REGISTRY:STRING=NEVER -DPython_INCLUDE_DIR:PATH=/home/amon/.pyenv/versions/3.10.6/include/python3.10 -DPython3_EXECUTABLE:PATH=/home/amon/.pyenv/versions/3.10.6/envs/l4casadi_install_2/bin/python3.10 -DPython3_ROOT_DIR:PATH=/home/amon/.pyenv/versions/3.10.6/envs/l4casadi_install_2 -DPython3_FIND_REGISTRY:STRING=NEVER -DPython3_INCLUDE_DIR:PATH=/home/amon/.pyenv/versions/3.10.6/include/python3.10 -DCMAKE_MAKE_PROGRAM:FILEPATH=/home/amon/.pyenv/versions/3.10.6/envs/l4casadi_install_2/bin/ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_TORCH_PATH=/home/amon/.pyenv/versions/3.10.6/envs/l4casadi_install_2/lib/python3.10/site-packages/torch
        Source directory:
          /home/amon/Repositories/l4casadi_fork/libl4casadi
        Working directory:
          /home/amon/Repositories/l4casadi_fork/_skbuild/linux-x86_64-3.10/cmake-build
      Please see CMake's output for more information.
      
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for l4casadi
Failed to build l4casadi
ERROR: Could not build wheels for l4casadi, which is required to install pyproject.toml-based projects
```

Updating the minimum CMake version to >= 3.5 fixes the issue. 

Best regards!